### PR TITLE
Fix regex for detecting project, context, tag

### DIFF
--- a/todotxtio.py
+++ b/todotxtio.py
@@ -19,7 +19,7 @@ __all__ = [
 todo_data_regex = re.compile('^(?:(x) )?(?:(\d{4}-\d{2}-\d{2}) )?(?:\(([A-Z])\) )?(?:(\d{4}-\d{2}-\d{2}) )?')
 todo_project_regex = re.compile(' \+(\S+)')
 todo_context_regex = re.compile(' @(\S+)')
-todo_tag_regex = re.compile(' (\S+):(\S+)')
+todo_tag_regex = re.compile(' (\S+):([^\s\/]+)')
 
 
 def from_dicts(todos):

--- a/todotxtio.py
+++ b/todotxtio.py
@@ -17,9 +17,9 @@ __all__ = [
 ]
 
 todo_data_regex = re.compile('^(?:(x) )?(?:(\d{4}-\d{2}-\d{2}) )?(?:\(([A-Z])\) )?(?:(\d{4}-\d{2}-\d{2}) )?')
-todo_project_regex = re.compile(' \+(\S*)')
-todo_context_regex = re.compile(' @(\S*)')
-todo_tag_regex = re.compile(' (\S*):(\S*)')
+todo_project_regex = re.compile(' \+(\S+)')
+todo_context_regex = re.compile(' @(\S+)')
+todo_tag_regex = re.compile(' (\S+):(\S+)')
 
 
 def from_dicts(todos):


### PR DESCRIPTION
This commit fixes the regex for detection of projects, contexts and tags
in the todo lines. It switches from "zero or more" quantifier to "one or
more" quantifier, because otherwise empty projects or contexts would be
allowed and something like "test:" would be a tag.